### PR TITLE
Add unit tests for tk.mybatis.mapper.util.StringUtil

### DIFF
--- a/core/src/test/java/tk/mybatis/mapper/util/StringUtilTest.java
+++ b/core/src/test/java/tk/mybatis/mapper/util/StringUtilTest.java
@@ -1,0 +1,43 @@
+package tk.mybatis.mapper.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import tk.mybatis.mapper.util.StringUtil;
+
+public class StringUtilTest {
+
+    @Test
+    public void toUpperAsciiInputaOutputA() {
+        final char c = 'a';
+        final char retval = StringUtil.toUpperAscii(c);
+        Assert.assertEquals('A', retval);
+    }
+
+    @Test
+    public void toUpperAsciiInputNotNullOutputNotNull() {
+        final char c = '\u0000';
+        final char retval = StringUtil.toUpperAscii(c);
+        Assert.assertEquals('\u0000', retval);
+    }
+
+    @Test
+    public void isLowercaseAlphaInputyOutputTrue() {
+        final char c = 'y';
+        final boolean retval = StringUtil.isLowercaseAlpha(c);
+        Assert.assertEquals(true, retval);
+    }
+
+    @Test
+    public void isLowercaseAlphaInputNotNullOutputFalse() {
+        final char c = '\u0000';
+        final boolean retval = StringUtil.isLowercaseAlpha(c);
+        Assert.assertEquals(false, retval);
+    }
+
+    @Test
+    public void isLowercaseAlphaInputNotNullOutputFalse2() {
+        final char c = '}';
+        final boolean retval = StringUtil.isLowercaseAlpha(c);
+        Assert.assertEquals(false, retval);
+    }
+}


### PR DESCRIPTION
Hi,

I've analysed your codebase and produced some unit tests for this class - tk.mybatis.mapper.util.StringUtil.

I've written the tests for these functions with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/datasheet).

Hopefully, these tests should help you detect regressions caused by future code changes.